### PR TITLE
Fix: Example repo paths

### DIFF
--- a/src/cloneExampleFolder.go
+++ b/src/cloneExampleFolder.go
@@ -8,8 +8,8 @@ import (
 )
 
 var examplePaths = map[string]string{
-	"typescript": "/examples/openai",
-	"python":     "/examples/get-started",
+	"typescript": "/openai",
+	"python":     "/get_started",
 }
 
 var repositoryUrls = map[string]string{


### PR DESCRIPTION
Why?
- We changed the location of all examples to root of the repositories 
- Python: Example folder is called 'get_started' and not 'get-started'